### PR TITLE
Adding cross-origin support for API routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
+    "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "enquirer": "^2.3.0",
     "express": "^4.16.4",

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ const passport = require("passport");
 const session = require("express-session");
 const bodyParser = require("body-parser");
 const ip = require("ip");
+const cors = require("cors");
 
 const server = require("./config/server");
 const passportConfig = require("./controller/passportConfig");
@@ -42,6 +43,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 // API
+app.use("/api", cors());
 app.all("/api", (req, res) => {
     res.sendStatus(204);
 });


### PR DESCRIPTION
(About 458a3ed3e1cd164956d9a85732fcf5d2186f9e51 : Don't ask me why I don't `app.all` directly; it won't work, I tried).