### PR TITLE
Add advanced filtering support for /api/subs endpoint

### DIFF
--- a/src/controller/database.js
+++ b/src/controller/database.js
@@ -290,9 +290,9 @@ function multipleQueriesFormatter (arg) {
  * @param {Number} page page number
  * @param {Number} count number of subs limited in the selected
  * @param {Number} size limit the size of page
- * @param {String[]||String} prob_id problem(s) to filter
- * @param {String[]||String} username user(s) to filter
- * @param {String[]||String} ext language(s) to filter
+ * @param {String[]|String} prob_id problem(s) to filter
+ * @param {String[]|String} username user(s) to filter
+ * @param {String[]|String} ext language(s) to filter
  * @returns {Promise<Array<ReturnSubmission>>} Array of submission if success
  */
 async function readAllSubmissions(page, size, count, prob_id, username, ext) {

--- a/src/routes/subs.js
+++ b/src/routes/subs.js
@@ -27,27 +27,27 @@ router.use(auth);
 router
     .route("/")
     .get((req, res) => {
-        let { page, size, count } = req.query;
+        let { page, size, count, prob_id, username, ext } = req.query;
 
         page = Number(page);
         size = Number(size);
         count = Number(count);
 
         if (req.user.isAdmin)
-            readAllSubmissions(page, size, count).then(
-                docs => {
+            readAllSubmissions(page, size, count, prob_id, username, ext).then(
+                (docs) => {
                     res.send(docs);
                 },
-                err => {
+                (err) => {
                     res.status(400).json(err.message);
                 }
             );
         else
             readUserSubmission(req.user._id, page, size, count).then(
-                docs => {
+                (docs) => {
                     res.send(docs);
                 },
-                err => {
+                (err) => {
                     res.status(400).json(err.message);
                 }
             );

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -1,0 +1,9 @@
+const chalk = require('chalk')
+/**
+ * @param {string} tag Log message prefix
+ * @param {string} fg Foreground color for prefix
+ * @param {string} bg Background color for prefix
+ */
+module.exports = (tag, fg, bg) => (s) => console.log(`${
+    chalk.bgGreenBright.black(new Date().toJSON)
+} | ${`[${chalk.bgHex(bg).hex(fg)(tag)}]`} ${s}`)


### PR DESCRIPTION
Added queries : 
* `prob_id` : Filtering by problems.
* `username` : Filtering by user.
* `ext` : Filtering by language (source file extension, as defined in `/api/info`.

Internal behaviours : 
- All queries support multiple argument, for example `/api/subs?prob_id=A&prob_id=B` would return submissions for problems A and B.
- In case of invalid data being passed : 
  - For `prob_id` & `ext`, passing an unknown problem ID or language would not trigger any abnormal behaviour : simply no data gets returned, as there are no submissions matching those criteria.
  - For `username`, passing an unknown user (don't mistake it with the user ID) will result in that particular query being ignored. 
    For example, with a database containing records for two contestants named `user1` & `user2`, `/api/subs?username=user3` would be considered as `/api/subs`. Similarly, `/api/subs?username=user1&username=user3` is equal to `/api/subs?username=user1`.