### PR TITLE
Adding default password criteria to sample config

### DIFF
--- a/contest.sample.json
+++ b/contest.sample.json
@@ -5,5 +5,5 @@
     "mode": "OI",
     "probList": ["LARES", "GCD"],
     "allowedCodeExt": [".C", ".CPP"],
-    "passwordCondition": ".{6, 18}"
+    "passwordRegex": ".{6,18}"
 }

--- a/contest.sample.json
+++ b/contest.sample.json
@@ -4,5 +4,6 @@
     "endTime": "2019-02-27T17:30:00.000Z",
     "mode": "OI",
     "probList": ["LARES", "GCD"],
-    "allowedCodeExt": [".C", ".CPP"]
+    "allowedCodeExt": [".C", ".CPP"],
+    "passwordCondition": ".{6, 18}"
 }

--- a/src/controller/database.js
+++ b/src/controller/database.js
@@ -3,6 +3,7 @@
 const bcrypt = require("bcryptjs");
 const { join } = require("path");
 const cwd = require("../config/cwd");
+const { passwordRegex } = require("../config/contest");
 const Datastore = require("nedb");
 const { isUsername, isPassword } = require("../util/userValid");
 
@@ -185,6 +186,7 @@ async function updateUserName(user_id, old_name, new_name) {
  */
 async function updateUserPassword(user_id, old_pass, new_pass) {
     if (!isPassword(new_pass)) throw new Error("Invalid new password");
+    if (!new_pass.match(passwordRegex)) throw new Error("Password does not match requirements");
     const newHashPass = bcrypt.hash(new_pass, bcrypt.genSaltSync(10));
 
     const dbUserPassHash = await readUserPassHash(user_id);

--- a/src/util/config/contestConfig.js
+++ b/src/util/config/contestConfig.js
@@ -39,7 +39,8 @@ function parseCtCfg(configData) {
         endTime,
         mode,
         probList,
-        allowedCodeExt
+        allowedCodeExt,
+        passwordRegex: pregex
     } = configData;
 
     name = String(name);
@@ -50,6 +51,9 @@ function parseCtCfg(configData) {
     startTime = parseTime(startTime);
     endTime = parseTime(endTime);
 
+    if (pregex && (typeof pregex !== 'string'))
+        throw new TypeError(`passwordRegex must be a string, got ${typeof pregex}`);
+
     if (startTime >= endTime) throw new Error("Start time is after end time");
 
     return {
@@ -58,7 +62,8 @@ function parseCtCfg(configData) {
         startTime: startTime,
         endTime: endTime,
         probList: parseContainer(probList),
-        allowedCodeExt: parseContainer(allowedCodeExt)
+        allowedCodeExt: parseContainer(allowedCodeExt),
+        passwordRegex: new RegExp(pregex ? pregex : '.{6,18}')
     };
 }
 


### PR DESCRIPTION
This enables setting custom rules for passwords.

However, whether this option is mandatory in the configuration is up to upstream maintainers.